### PR TITLE
Use ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,11 @@ repos:
       - id: end-of-file-fixer
       - id: check-toml
       - id: check-merge-conflict
-  - repo: https://github.com/psf/black
-    rev: 22.10.0
-    hooks:
-      - id: black
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: 'v0.0.256'
     hooks:
       - id: ruff
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+      - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,12 +14,7 @@ repos:
     rev: 22.10.0
     hooks:
       - id: black
-  - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.256'
     hooks:
-      - id: isort
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies: [flake8-isort, Flake8-pyproject]
+      - id: ruff

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,3 @@
 black
-isort
-flake8
-flake8-pyproject
 pre-commit
+ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,22 +27,13 @@ version = {attr = "mdl.isoscelles.__version__"}
 
 [tool.black]
 line-length = 88
-target-version = ['py39']
+target-version = ["py39"]
 include = '\.pyi?$'
 
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
-line_length = 88
+[tool.ruff]
+line-length = 88
+src = ["src"]
+ignore = ["E501"]
 
-[tool.flake8]
-max-line-length = 88
-exclude = ['.git', '.tox', 'venv']
-ignore = ['E203', 'E231', 'E501', 'W503']
-per-file-ignores = [
-    '__init__.py:F401',
-]
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]

--- a/src/mdl/isoscelles/leiden.py
+++ b/src/mdl/isoscelles/leiden.py
@@ -49,7 +49,8 @@ def leiden_sweep(
 
         if cutoff is not None and c0c1_ratio < cutoff:
             log.info(
-                f"Reached nontrivial clustering with c0/c1 ratio {c0c1_ratio:.1f}, stopping"
+                f"Reached nontrivial clustering with c0/c1 ratio {c0c1_ratio:.1f},"
+                " stopping"
             )
             break
     else:


### PR DESCRIPTION
Switched the pre-commit from `isort` and `flake8` to [`ruff`](https://beta.ruff.rs/docs/) because a) it's a little simpler to have one tool instead of two (plus plugins), b) it's faster and c) it's cool and new